### PR TITLE
change postProcess order for clipboard copy

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ export default class VariablesPlugin extends Plugin {
 				var cleanedValue = DOMPurify.sanitize(variable.value);
 				element.innerHTML = element.innerHTML.replaceAll(variable.name, cleanedValue);
 			}
-		});
+		}, -1);
 
 		// https://github.com/jffaust/obsidian-variables/issues/4
 		//this.registerEditorExtension(livePreviewPostProcessorPlugin(this));


### PR DESCRIPTION
prevent "copy to clipboard" button to be disabled in Read mode, 
by modifying order of `registerMarkdownPostProcessor`.

To be tested more toroughly to search for potential side effect.